### PR TITLE
Added option to prevent destroying the window when focus is lost when PLOTINUS_UNFOCUSED_PREVENT_CLOSE=true

### DIFF
--- a/src/PopupWindow.vala
+++ b/src/PopupWindow.vala
@@ -59,11 +59,15 @@ class Plotinus.PopupWindow : Gtk.Window {
     });
     command_list.row_activated.connect(() => search_entry.activate());
 
-    add_events(Gdk.EventMask.FOCUS_CHANGE_MASK);
-    focus_out_event.connect(() => {
-      destroy();
-      return true;
-    });
+    // Allow disabling of destroying on focus out by setting the environemnt variable PLOTINUS_UNFOCUSED_PREVENT_CLOSE=true
+    unowned string unfocus_prevent_close = GLib.Environment.get_variable("PLOTINUS_UNFOCUSED_PREVENT_CLOSE");
+    if (unfocus_prevent_close != "true") {
+        add_events(Gdk.EventMask.FOCUS_CHANGE_MASK);
+        focus_out_event.connect(() => {
+          destroy();
+          return true;
+        });
+    }
 
     add_events(Gdk.EventMask.KEY_PRESS_MASK);
     key_press_event.connect((event) => {


### PR DESCRIPTION
When the Plotinus window loses focus, it usually destroys the window. This is particulary irritating seeing as I have my WM configured to focus where the mouse is, so if the mouse doesn't happen to be over the Plotinus window, it sometimes gets destroyed immediately.

I added the option of setting the environment variable `PLOTINUS_UNFOCUSED_PREVENT_CLOSE` to `true` to prevent this behaviour. I'll leave it to you to add this to the readme if this does happen to get added.

Thanks ;)